### PR TITLE
Mod Hashing, Verification Screen and Additional Proof Zipping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/net.java.dev.jna/jna-platform
 	shadow(implementation group: 'net.java.dev.jna', name: 'jna-platform', version: '5.15.0')
+
+	// SpeedrunAPI
+	// check for the latest versions at https://jitpack.io/#kingcontaria/speedrunapi
+	modImplementation "com.github.KingContaria:SpeedrunAPI:v1.2.1"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,11 @@ dependencies {
 	// SpeedrunAPI
 	// check for the latest versions at https://jitpack.io/#kingcontaria/speedrunapi
 	modImplementation "com.github.KingContaria:SpeedrunAPI:v1.2.1"
+
+	// check for the latest versions at https://jitpack.io/#kingcontaria/atum-rewrite
+	modImplementation ("com.github.KingContaria:atum-rewrite:v2.4") {
+		transitive = false
+	}
 }
 
 processResources {

--- a/src/main/java/exersolver/mcsrfairplay/MCSRFairplay.java
+++ b/src/main/java/exersolver/mcsrfairplay/MCSRFairplay.java
@@ -1,14 +1,18 @@
 package exersolver.mcsrfairplay;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.nio.file.Path;
 
 public class MCSRFairplay implements ClientModInitializer, PreLaunchEntrypoint {
 	public static final String MOD_ID = "mcsrfairplay";
 
 	public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
+	public static final Path DIRECTORY = FabricLoader.getInstance().getGameDir().resolve("mcsrfairplay");
 
     @Override
 	public void onPreLaunch() {

--- a/src/main/java/exersolver/mcsrfairplay/MCSRFairplay.java
+++ b/src/main/java/exersolver/mcsrfairplay/MCSRFairplay.java
@@ -1,14 +1,59 @@
 package exersolver.mcsrfairplay;
 
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.fabricmc.api.ClientModInitializer;
-
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class MCSRFairplay implements ClientModInitializer {
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedInputStream;
+
+public class MCSRFairplay implements ClientModInitializer, PreLaunchEntrypoint {
 	public static final String MOD_ID = "mcsrfairplay";
 
 	public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
+
+	public static final Object2IntMap<String> MOD_HASHES = new Object2IntOpenHashMap<>();
+
+	@Override
+	public void onPreLaunch() {
+		LOGGER.info("Generating hashes for loaded mods...");
+
+		int sessionId = (int) System.currentTimeMillis();
+		int sessionHash = sessionId;
+
+		for (ModContainer mod : FabricLoader.getInstance().getAllMods()) {
+			int hash = 1;
+			for (Path root : mod.getRootPaths()) {
+				try (Stream<Path> stream = Files.walk(root)) {
+					hash = hash * 31 + stream.filter(path -> !Files.isDirectory(path)).mapToInt(path -> {
+						try (CheckedInputStream checked = new CheckedInputStream(Files.newInputStream(path), new CRC32())) {
+							return path.hashCode() * 31 + Long.hashCode(checked.getChecksum().getValue());
+						} catch (IOException e) {
+							throw new RuntimeException(e);
+						}
+					}).reduce((i, j) -> i * 31 + j).orElse(1);
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+			sessionHash = (sessionHash * 31 + hash) * 31 + sessionId;
+
+			String id = mod.getMetadata().getId();
+			MOD_HASHES.put(id, hash);
+			LOGGER.info("{}: {}", id, hash);
+		}
+
+		LOGGER.info("Finished generating hashes for session {}", Math.abs(sessionId) + "-" + Math.abs(sessionHash));
+	}
 
 	@Override
 	public void onInitializeClient() {

--- a/src/main/java/exersolver/mcsrfairplay/MCSRFairplay.java
+++ b/src/main/java/exersolver/mcsrfairplay/MCSRFairplay.java
@@ -1,58 +1,18 @@
 package exersolver.mcsrfairplay;
 
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.stream.Stream;
-import java.util.zip.CRC32;
-import java.util.zip.CheckedInputStream;
 
 public class MCSRFairplay implements ClientModInitializer, PreLaunchEntrypoint {
 	public static final String MOD_ID = "mcsrfairplay";
 
 	public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
 
-	public static final Object2IntMap<String> MOD_HASHES = new Object2IntOpenHashMap<>();
-
-	@Override
+    @Override
 	public void onPreLaunch() {
-		LOGGER.info("Generating hashes for loaded mods...");
-
-		int sessionId = (int) System.currentTimeMillis();
-		int sessionHash = sessionId;
-
-		for (ModContainer mod : FabricLoader.getInstance().getAllMods()) {
-			int hash = 1;
-			for (Path root : mod.getRootPaths()) {
-				try (Stream<Path> stream = Files.walk(root)) {
-					hash = hash * 31 + stream.filter(path -> !Files.isDirectory(path)).mapToInt(path -> {
-						try (CheckedInputStream checked = new CheckedInputStream(Files.newInputStream(path), new CRC32())) {
-							return path.hashCode() * 31 + Long.hashCode(checked.getChecksum().getValue());
-						} catch (IOException e) {
-							throw new RuntimeException(e);
-						}
-					}).reduce((i, j) -> i * 31 + j).orElse(1);
-				} catch (IOException e) {
-					throw new RuntimeException(e);
-				}
-			}
-			sessionHash = (sessionHash * 31 + hash) * 31 + sessionId;
-
-			String id = mod.getMetadata().getId();
-			MOD_HASHES.put(id, hash);
-			LOGGER.info("{}: {}", id, hash);
-		}
-
-		LOGGER.info("Finished generating hashes for session {}", Math.abs(sessionId) + "-" + Math.abs(sessionHash));
+		ModHashing.init();
 	}
 
 	@Override

--- a/src/main/java/exersolver/mcsrfairplay/MCSRFairplay.java
+++ b/src/main/java/exersolver/mcsrfairplay/MCSRFairplay.java
@@ -14,6 +14,8 @@ public class MCSRFairplay implements ClientModInitializer, PreLaunchEntrypoint {
 	public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
 	public static final Path DIRECTORY = FabricLoader.getInstance().getGameDir().resolve("mcsrfairplay");
 
+	public static final boolean HAS_ATUM = FabricLoader.getInstance().isModLoaded("atum");
+
     @Override
 	public void onPreLaunch() {
 		ModHashing.init();

--- a/src/main/java/exersolver/mcsrfairplay/ModHashing.java
+++ b/src/main/java/exersolver/mcsrfairplay/ModHashing.java
@@ -21,7 +21,9 @@ public class ModHashing {
     public static final Map<String, String> MOD_HASHES = new HashMap<>();
     public static final Map<String, String> FILE_HASHES = new HashMap<>();
 
-    public static void init() {
+    public static String SESSION;
+
+    static {
         MCSRFairplay.LOGGER.info("Generating hashes for loaded mods...");
 
         int sessionId = (int) System.currentTimeMillis();
@@ -50,7 +52,11 @@ public class ModHashing {
             sessionHash = sessionHash * 31 + modHash.hashCode() * sessionId;
         }
 
-        MCSRFairplay.LOGGER.info("Finished generating hashes for session {}", Math.abs(sessionId) + "-" + Math.abs(sessionHash));
+        SESSION = Math.abs(sessionId) + "-" + Math.abs(sessionHash);
+        MCSRFairplay.LOGGER.info("Finished generating hashes for session {}", SESSION);
+    }
+
+    public static void init() {
     }
 
     private static String hashMod(ModContainer mod, MessageDigest sha512) {

--- a/src/main/java/exersolver/mcsrfairplay/ModHashing.java
+++ b/src/main/java/exersolver/mcsrfairplay/ModHashing.java
@@ -1,0 +1,97 @@
+package exersolver.mcsrfairplay;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.fabricmc.loader.api.metadata.ModOrigin;
+import org.apache.commons.codec.binary.Hex;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class ModHashing {
+    public static final Map<String, String> MOD_HASHES = new HashMap<>();
+    public static final Map<String, String> FILE_HASHES = new HashMap<>();
+
+    public static void init() {
+        MCSRFairplay.LOGGER.info("Generating hashes for loaded mods...");
+
+        int sessionId = (int) System.currentTimeMillis();
+        int sessionHash = sessionId;
+
+        MessageDigest sha512;
+        try {
+            sha512 = MessageDigest.getInstance("SHA-512");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+
+        for (ModContainer mod : FabricLoader.getInstance().getAllMods()) {
+            String id = mod.getMetadata().getId();
+            String modHash = hashMod(mod, sha512);
+            String fileHash = hashFile(mod, sha512);
+
+            MOD_HASHES.put(id, modHash);
+            MCSRFairplay.LOGGER.info("{}: {}", id, modHash);
+
+            if (fileHash != null) {
+                FILE_HASHES.put(id, fileHash);
+                MCSRFairplay.LOGGER.info("{} (file): {}", id, fileHash);
+            }
+
+            sessionHash = sessionHash * 31 + modHash.hashCode() * sessionId;
+        }
+
+        MCSRFairplay.LOGGER.info("Finished generating hashes for session {}", Math.abs(sessionId) + "-" + Math.abs(sessionHash));
+    }
+
+    private static String hashMod(ModContainer mod, MessageDigest sha512) {
+        for (Path root : mod.getRootPaths()) {
+            try (Stream<Path> stream = Files.walk(root)) {
+                stream.filter(path -> !Files.isDirectory(path)).forEach(path -> {
+                    try {
+                        sha512.update(path.toString().getBytes(StandardCharsets.UTF_8));
+                        sha512.update(Files.readAllBytes(path));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Hex.encodeHexString(sha512.digest());
+    }
+
+    private static String hashFile(ModContainer mod, MessageDigest sha512) {
+        ModMetadata metadata = mod.getMetadata();
+        ModOrigin origin = mod.getOrigin();
+        if (metadata.getType().equals("builtin") || origin.getKind() != ModOrigin.Kind.PATH) {
+            return null;
+        }
+        List<Path> paths = origin.getPaths();
+        if (paths.size() != 1) {
+            MCSRFairplay.LOGGER.warn("Mod {} has multiple origin paths, skipping hashing.", metadata.getId());
+            return null;
+        }
+        Path path = paths.get(0);
+        if (Files.isDirectory(path)) {
+            MCSRFairplay.LOGGER.warn("Mod {} has a directory origin, skipping hashing.", metadata.getId());
+            return null;
+        }
+        try {
+            sha512.update(Files.readAllBytes(paths.get(0)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return Hex.encodeHexString(sha512.digest());
+    }
+}

--- a/src/main/java/exersolver/mcsrfairplay/compat/AtumCompat.java
+++ b/src/main/java/exersolver/mcsrfairplay/compat/AtumCompat.java
@@ -1,0 +1,9 @@
+package exersolver.mcsrfairplay.compat;
+
+import me.voidxwalker.autoreset.Atum;
+
+public class AtumCompat {
+    public static void stopRunning() {
+        Atum.stopRunning();
+    }
+}

--- a/src/main/java/exersolver/mcsrfairplay/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/exersolver/mcsrfairplay/mixin/ClientPlayerEntityMixin.java
@@ -1,6 +1,7 @@
 package exersolver.mcsrfairplay.mixin;
 
 import exersolver.mcsrfairplay.InputListener;
+import exersolver.mcsrfairplay.ModHashing;
 import exersolver.mcsrfairplay.output.BufferedCryptoZipWriter;
 import exersolver.mcsrfairplay.output.OutputUtils;
 import net.minecraft.client.MinecraftClient;
@@ -36,7 +37,7 @@ public abstract class ClientPlayerEntityMixin {
                                         .withClickEvent(new ClickEvent(ClickEvent.Action.CHANGE_PAGE, "mcsrfairplay.open_verification_screen"))
                                         .setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TranslatableText("mcsrfairplay.gui.verification.tooltip")))
                                 )
-                ))
+                )).append(" (" + ModHashing.SESSION + ")")
         );
     }
 }

--- a/src/main/java/exersolver/mcsrfairplay/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/exersolver/mcsrfairplay/mixin/ClientPlayerEntityMixin.java
@@ -5,15 +5,15 @@ import exersolver.mcsrfairplay.output.BufferedCryptoZipWriter;
 import exersolver.mcsrfairplay.output.OutputUtils;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.text.LiteralText;
-import net.minecraft.text.Text;
+import net.minecraft.text.*;
+import net.minecraft.util.Formatting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPlayerEntity.class)
-public class ClientPlayerEntityMixin {
+public abstract class ClientPlayerEntityMixin {
 
     @Inject(at = @At("HEAD"), method = "sendChatMessage")
     private void printHashInChatOnSeedCommand(String message, CallbackInfo ci) {
@@ -28,5 +28,15 @@ public class ClientPlayerEntityMixin {
         String hash = fileWriter.getHashHex();
         Text text = new LiteralText( fileWriter.getHashFileName() + ": " + hash);
         MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(text);
+
+        MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(
+                new TranslatableText("mcsrfairplay.gui.verification.message", Texts.bracketed(
+                        new TranslatableText("mcsrfairplay.gui.verification.here")
+                                .styled(style -> style.withColor(Formatting.GREEN)
+                                        .withClickEvent(new ClickEvent(ClickEvent.Action.CHANGE_PAGE, "mcsrfairplay.open_verification_screen"))
+                                        .setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TranslatableText("mcsrfairplay.gui.verification.tooltip")))
+                                )
+                ))
+        );
     }
 }

--- a/src/main/java/exersolver/mcsrfairplay/mixin/MinecraftClientMixin.java
+++ b/src/main/java/exersolver/mcsrfairplay/mixin/MinecraftClientMixin.java
@@ -1,7 +1,10 @@
 package exersolver.mcsrfairplay.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import exersolver.mcsrfairplay.InputListener;
 import exersolver.mcsrfairplay.output.OutputUtils;
+import exersolver.mcsrfairplay.verification_screen.ZipFilesScreen;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.world.ClientWorld;
@@ -51,5 +54,12 @@ public abstract class MinecraftClientMixin {
 	)
 	private void onScreenChanged(Screen screen, CallbackInfo ci) {
 		InputListener.onScreenChanged(screen);
+	}
+
+	@WrapMethod(method = "openScreen")
+	private void captureScreensDuringZipping(Screen screen, Operation<Void> original) {
+		if (!ZipFilesScreen.captureScreen(screen)) {
+			original.call(screen);
+		}
 	}
 }

--- a/src/main/java/exersolver/mcsrfairplay/mixin/ScreenMixin.java
+++ b/src/main/java/exersolver/mcsrfairplay/mixin/ScreenMixin.java
@@ -1,14 +1,12 @@
 package exersolver.mcsrfairplay.mixin;
 
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
-import com.llamalad7.mixinextras.sugar.Cancellable;
 import exersolver.mcsrfairplay.verification_screen.VerificationScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.ClickEvent;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Screen.class)
 public abstract class ScreenMixin {
@@ -21,7 +19,7 @@ public abstract class ScreenMixin {
                     remap = false
             )
     )
-    private boolean openVerificationScreenClickEvent(Logger logger, String string, Object o, @Cancellable CallbackInfoReturnable<Boolean> cir) {
+    private boolean openVerificationScreenClickEvent(Logger logger, String string, Object o) {
         ClickEvent event = (ClickEvent) o;
         if (event.getAction() == ClickEvent.Action.CHANGE_PAGE && event.getValue().equals("mcsrfairplay.open_verification_screen")) {
             VerificationScreen.start();

--- a/src/main/java/exersolver/mcsrfairplay/mixin/ScreenMixin.java
+++ b/src/main/java/exersolver/mcsrfairplay/mixin/ScreenMixin.java
@@ -1,0 +1,32 @@
+package exersolver.mcsrfairplay.mixin;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Cancellable;
+import exersolver.mcsrfairplay.verification_screen.VerificationScreen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.text.ClickEvent;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Screen.class)
+public abstract class ScreenMixin {
+
+    @WrapWithCondition(
+            method = "handleTextClick",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;)V"
+            )
+    )
+    private boolean openVerificationScreenClickEvent(Logger logger, String string, Object o, @Cancellable CallbackInfoReturnable<Boolean> cir) {
+        ClickEvent event = (ClickEvent) o;
+        if (event.getAction() == ClickEvent.Action.CHANGE_PAGE && event.getValue().equals("mcsrfairplay.open_verification_screen")) {
+            MinecraftClient.getInstance().openScreen(new VerificationScreen((Screen) (Object) this));
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/exersolver/mcsrfairplay/mixin/ScreenMixin.java
+++ b/src/main/java/exersolver/mcsrfairplay/mixin/ScreenMixin.java
@@ -18,7 +18,8 @@ public abstract class ScreenMixin {
             method = "handleTextClick",
             at = @At(
                     value = "INVOKE",
-                    target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;)V"
+                    target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;)V",
+                    remap = false
             )
     )
     private boolean openVerificationScreenClickEvent(Logger logger, String string, Object o, @Cancellable CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/java/exersolver/mcsrfairplay/mixin/ScreenMixin.java
+++ b/src/main/java/exersolver/mcsrfairplay/mixin/ScreenMixin.java
@@ -3,7 +3,6 @@ package exersolver.mcsrfairplay.mixin;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.sugar.Cancellable;
 import exersolver.mcsrfairplay.verification_screen.VerificationScreen;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.ClickEvent;
 import org.apache.logging.log4j.Logger;
@@ -25,7 +24,7 @@ public abstract class ScreenMixin {
     private boolean openVerificationScreenClickEvent(Logger logger, String string, Object o, @Cancellable CallbackInfoReturnable<Boolean> cir) {
         ClickEvent event = (ClickEvent) o;
         if (event.getAction() == ClickEvent.Action.CHANGE_PAGE && event.getValue().equals("mcsrfairplay.open_verification_screen")) {
-            MinecraftClient.getInstance().openScreen(new VerificationScreen((Screen) (Object) this));
+            VerificationScreen.start();
             return false;
         }
         return true;

--- a/src/main/java/exersolver/mcsrfairplay/mixin/accessor/MinecraftClientAccessor.java
+++ b/src/main/java/exersolver/mcsrfairplay/mixin/accessor/MinecraftClientAccessor.java
@@ -1,0 +1,11 @@
+package exersolver.mcsrfairplay.mixin.accessor;
+
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(MinecraftClient.class)
+public interface MinecraftClientAccessor {
+    @Invoker("render")
+    void mcsrfairplay$render(boolean tick);
+}

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/DataPackVerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/DataPackVerificationScreen.java
@@ -2,7 +2,6 @@ package exersolver.mcsrfairplay.verification_screen;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ScreenTexts;
 import net.minecraft.client.gui.screen.pack.DataPackScreen;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.server.MinecraftServer;
@@ -20,7 +19,6 @@ public class DataPackVerificationScreen extends VerificationScreen {
     protected void init() {
         this.dataPackScreen.init(this.client, this.width, this.height);
         super.init();
-        this.next.setMessage(ScreenTexts.DONE);
     }
 
     @Override
@@ -32,6 +30,6 @@ public class DataPackVerificationScreen extends VerificationScreen {
 
     @Override
     public void onClose() {
-        MinecraftClient.getInstance().openScreen(this.parent);
+        MinecraftClient.getInstance().openScreen(new ZipFilesScreen(this.parent));
     }
 }

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/DataPackVerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/DataPackVerificationScreen.java
@@ -1,0 +1,37 @@
+package exersolver.mcsrfairplay.verification_screen;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ScreenTexts;
+import net.minecraft.client.gui.screen.pack.DataPackScreen;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.WorldSavePath;
+
+public class DataPackVerificationScreen extends VerificationScreen {
+    private final DataPackScreen dataPackScreen;
+
+    public DataPackVerificationScreen(Screen parent, MinecraftServer server) {
+        super(parent);
+        this.dataPackScreen = new DataPackScreen(null, server.getDataPackManager(), manager -> {}, server.getSavePath(WorldSavePath.DATAPACKS).toFile());
+    }
+
+    @Override
+    protected void init() {
+        this.dataPackScreen.init(this.client, this.width, this.height);
+        super.init();
+        this.next.setMessage(ScreenTexts.DONE);
+    }
+
+    @Override
+    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+        this.renderBackgroundTexture(0);
+        this.dataPackScreen.render(matrices, 0, 0, delta);
+        super.render(matrices, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public void onClose() {
+        MinecraftClient.getInstance().openScreen(this.parent);
+    }
+}

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/F3VerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/F3VerificationScreen.java
@@ -1,0 +1,45 @@
+package exersolver.mcsrfairplay.verification_screen;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.hud.DebugHud;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ScreenTexts;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.util.math.MatrixStack;
+
+public class F3VerificationScreen extends VerificationScreen {
+    private final DebugHud debugHud;
+    private ButtonWidget done;
+    private long activateDone;
+
+    public F3VerificationScreen(Screen parent) {
+        super(parent);
+        this.debugHud = new DebugHud(MinecraftClient.getInstance());
+    }
+
+    @Override
+    protected void init() {
+        this.done = this.addButton(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, ScreenTexts.DONE, button -> this.onClose()));
+        this.done.active = false;
+        this.activateDone = System.currentTimeMillis() + 500;
+    }
+
+    @Override
+    public void tick() {
+        if (!this.done.active && System.currentTimeMillis() > this.activateDone) {
+            this.done.active = true;
+        }
+    }
+
+    @Override
+    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+        this.renderBackgroundTexture(0);
+        this.debugHud.render(matrices);
+        super.render(matrices, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public void onClose() {
+        MinecraftClient.getInstance().openScreen(this.parent);
+    }
+}

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/F3VerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/F3VerificationScreen.java
@@ -3,32 +3,14 @@ package exersolver.mcsrfairplay.verification_screen;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.DebugHud;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ScreenTexts;
-import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.util.math.MatrixStack;
 
 public class F3VerificationScreen extends VerificationScreen {
     private final DebugHud debugHud;
-    private ButtonWidget done;
-    private long activateDone;
 
     public F3VerificationScreen(Screen parent) {
         super(parent);
         this.debugHud = new DebugHud(MinecraftClient.getInstance());
-    }
-
-    @Override
-    protected void init() {
-        this.done = this.addButton(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, ScreenTexts.DONE, button -> this.onClose()));
-        this.done.active = false;
-        this.activateDone = System.currentTimeMillis() + 500;
-    }
-
-    @Override
-    public void tick() {
-        if (!this.done.active && System.currentTimeMillis() > this.activateDone) {
-            this.done.active = true;
-        }
     }
 
     @Override
@@ -40,6 +22,6 @@ public class F3VerificationScreen extends VerificationScreen {
 
     @Override
     public void onClose() {
-        MinecraftClient.getInstance().openScreen(this.parent);
+        MinecraftClient.getInstance().openScreen(new ResourcePackVerificationScreen(this.parent));
     }
 }

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ModListWidget.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ModListWidget.java
@@ -1,0 +1,118 @@
+package exersolver.mcsrfairplay.verification_screen;
+
+import exersolver.mcsrfairplay.MCSRFairplay;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.widget.ElementListWidget;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public class ModListWidget extends ElementListWidget<ModListWidget.Entry> {
+
+    public ModListWidget(MinecraftClient minecraftClient, int width, int height, int top, int bottom, int itemHeight) {
+        super(minecraftClient, width, height, top, bottom, itemHeight);
+
+        List<ModContainer> mods = new ArrayList<>(FabricLoader.getInstance().getAllMods());
+        mods.sort(Comparator.comparing(mod -> mod.getMetadata().getName()));
+        for (ModContainer mod : mods) {
+            this.addEntry(new Entry(mod.getMetadata()));
+        }
+    }
+
+    public boolean isScrolledToBottom() {
+        return this.getRowTop(this.children().size() - 1) + this.itemHeight <= this.bottom;
+    }
+
+    @Override
+    public int getRowWidth() {
+        return this.width - 50;
+    }
+
+    @Override
+    protected int getRowLeft() {
+        return 25;
+    }
+
+    @Override
+    protected int getScrollbarPositionX() {
+        return this.width - 6;
+    }
+
+    @Override
+    protected int getMaxPosition() {
+        return super.getMaxPosition();
+    }
+
+    @Override
+    public Optional<Element> hoveredElement(double mouseX, double mouseY) {
+        return super.hoveredElement(mouseX, mouseY);
+    }
+
+    @Override
+    public void mouseMoved(double mouseX, double mouseY) {
+        super.mouseMoved(mouseX, mouseY);
+    }
+
+    @Override
+    public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
+        return super.keyReleased(keyCode, scanCode, modifiers);
+    }
+
+    @Override
+    public boolean charTyped(char chr, int keyCode) {
+        return super.charTyped(chr, keyCode);
+    }
+
+    @Override
+    public void setInitialFocus(@Nullable Element element) {
+        super.setInitialFocus(element);
+    }
+
+    @Override
+    public void focusOn(@Nullable Element element) {
+        super.focusOn(element);
+    }
+
+    public static class Entry extends ElementListWidget.Entry<Entry> {
+        private final Text name;
+        private final Text hash;
+
+        public Entry(ModMetadata mod) {
+            this.name = new LiteralText(mod.getName()).append(new LiteralText(" (" + mod.getId() + "-" + mod.getVersion().getFriendlyString() + ")").formatted(Formatting.GRAY));
+            this.hash = new LiteralText(String.valueOf(MCSRFairplay.MOD_HASHES.getInt(mod.getId())));
+        }
+
+        @Override
+        public List<? extends Element> children() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void render(MatrixStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+            TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
+            textRenderer.draw(
+                    matrices,
+                    this.name,
+                    x,
+                    y + 3,
+                    0xFFFFFF
+            );
+            textRenderer.draw(
+                    matrices,
+                    this.hash,
+                    x + entryWidth - textRenderer.getWidth(this.hash),
+                    y + 3,
+                    0xFFFFFF
+            );
+        }
+    }
+}

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ModListWidget.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ModListWidget.java
@@ -7,12 +7,10 @@ import net.minecraft.client.gui.widget.ElementListWidget;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.StringRenderable;
 import net.minecraft.text.Text;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public class ModListWidget extends ElementListWidget<ModListWidget.Entry> {
     private double lastScrollAmount = 0.0;
@@ -57,41 +55,6 @@ public class ModListWidget extends ElementListWidget<ModListWidget.Entry> {
     @Override
     public void setScrollAmount(double amount) {
         super.setScrollAmount(Math.min(amount, this.lastScrollAmount + this.height / 4.0));
-    }
-
-    @Override
-    protected int getMaxPosition() {
-        return super.getMaxPosition();
-    }
-
-    @Override
-    public Optional<Element> hoveredElement(double mouseX, double mouseY) {
-        return super.hoveredElement(mouseX, mouseY);
-    }
-
-    @Override
-    public void mouseMoved(double mouseX, double mouseY) {
-        super.mouseMoved(mouseX, mouseY);
-    }
-
-    @Override
-    public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
-        return super.keyReleased(keyCode, scanCode, modifiers);
-    }
-
-    @Override
-    public boolean charTyped(char chr, int keyCode) {
-        return super.charTyped(chr, keyCode);
-    }
-
-    @Override
-    public void setInitialFocus(@Nullable Element element) {
-        super.setInitialFocus(element);
-    }
-
-    @Override
-    public void focusOn(@Nullable Element element) {
-        super.focusOn(element);
     }
 
     public static class Entry extends ElementListWidget.Entry<Entry> {

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ModListWidget.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ModListWidget.java
@@ -14,10 +14,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class VerificationListWidget extends ElementListWidget<VerificationListWidget.Entry> {
+public class ModListWidget extends ElementListWidget<ModListWidget.Entry> {
     private double lastScrollAmount = 0.0;
 
-    public VerificationListWidget(MinecraftClient minecraftClient, int width, int height, int top, int bottom, Map<Text, List<List<StringRenderable>>> hashes, int totalHeight) {
+    public ModListWidget(MinecraftClient minecraftClient, int width, int height, int top, int bottom, Map<Text, List<List<StringRenderable>>> hashes, int totalHeight) {
         super(minecraftClient, width, height, top, bottom, totalHeight);
         // we cheat the list by only giving it a single entry,
         // so we can implement our own spacing instead of a fixed itemHeight

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ModListWidget.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ModListWidget.java
@@ -56,7 +56,7 @@ public class ModListWidget extends ElementListWidget<ModListWidget.Entry> {
 
     @Override
     public void setScrollAmount(double amount) {
-        super.setScrollAmount(Math.min(amount, this.lastScrollAmount + 50.0));
+        super.setScrollAmount(Math.min(amount, this.lastScrollAmount + this.height / 4.0));
     }
 
     @Override

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ModVerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ModVerificationScreen.java
@@ -5,7 +5,6 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.StringRenderable;
@@ -17,7 +16,6 @@ import java.util.*;
 
 public class ModVerificationScreen extends VerificationScreen {
     private ModListWidget list;
-    private ButtonWidget next;
     private boolean hasScrolledToBottom;
 
     public ModVerificationScreen(Screen parent) {
@@ -53,18 +51,23 @@ public class ModVerificationScreen extends VerificationScreen {
                 3 + hashes.values().stream().mapToInt(lists -> 14 + lists.stream().mapToInt(list -> list.size() * 10 + 2).sum() + 3).sum()
         ));
 
-        this.next = this.addButton(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, new TranslatableText("mcsrfairplay.gui.verification.please_scroll"), button -> this.onClose()));
-        this.next.active = false;
+        super.init();
+        this.next.setMessage(new TranslatableText("mcsrfairplay.gui.verification.please_scroll"));
     }
 
     @Override
     public void tick() {
+        this.list.updateLastScrollAmount();
         if (!this.hasScrolledToBottom && this.list.isScrolledToBottom()) {
             this.next.setMessage(NEXT);
-            this.next.active = true;
             this.hasScrolledToBottom = true;
         }
-        this.list.updateLastScrollAmount();
+        super.tick();
+    }
+
+    @Override
+    protected boolean shouldActivateNext() {
+        return this.hasScrolledToBottom && super.shouldActivateNext();
     }
 
     @Override

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ModVerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ModVerificationScreen.java
@@ -1,0 +1,82 @@
+package exersolver.mcsrfairplay.verification_screen;
+
+import exersolver.mcsrfairplay.ModHashing;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.StringRenderable;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Formatting;
+
+import java.util.*;
+
+public class ModVerificationScreen extends VerificationScreen {
+    private ModListWidget list;
+    private ButtonWidget next;
+    private boolean hasScrolledToBottom;
+
+    public ModVerificationScreen(Screen parent) {
+        super(parent);
+    }
+
+    @Override
+    protected void init() {
+        Map<Text, List<List<StringRenderable>>> hashes = new LinkedHashMap<>();
+
+        List<ModContainer> mods = new ArrayList<>(FabricLoader.getInstance().getAllMods());
+        mods.sort(Comparator.comparing(mod -> mod.getMetadata().getName()));
+        for (ModContainer mod : mods) {
+            String id = mod.getMetadata().getId();
+            String modHash = ModHashing.MOD_HASHES.get(id);
+            String fileHash = ModHashing.FILE_HASHES.get(id);
+
+            Text text = new LiteralText(mod.getMetadata().getName()).append(
+                    new LiteralText(" (" + id + "-" + mod.getMetadata().getVersion().getFriendlyString() + ")").formatted(Formatting.GRAY)
+            );
+
+            List<List<StringRenderable>> lists = new ArrayList<>();
+            lists.add(this.textRenderer.wrapLines(StringRenderable.plain(modHash), this.width - 30));
+            if (fileHash != null) {
+                lists.add(this.textRenderer.wrapLines(StringRenderable.plain(fileHash), this.width - 30));
+            }
+
+            hashes.put(text, lists);
+        }
+
+        this.list = this.addChild(new ModListWidget(
+                this.client, this.width, this.height, 32, this.height - 32, hashes,
+                3 + hashes.values().stream().mapToInt(lists -> 14 + lists.stream().mapToInt(list -> list.size() * 10 + 2).sum() + 3).sum()
+        ));
+
+        this.next = this.addButton(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, new TranslatableText("mcsrfairplay.gui.verification.please_scroll"), button -> this.onClose()));
+        this.next.active = false;
+    }
+
+    @Override
+    public void tick() {
+        if (!this.hasScrolledToBottom && this.list.isScrolledToBottom()) {
+            this.next.setMessage(NEXT);
+            this.next.active = true;
+            this.hasScrolledToBottom = true;
+        }
+        this.list.updateLastScrollAmount();
+    }
+
+    @Override
+    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+        this.renderBackground(matrices);
+        this.list.render(matrices, mouseX, mouseY, delta);
+        this.drawCenteredText(matrices, this.textRenderer, this.title, this.width / 2, 15, 0xFFFFFF);
+        super.render(matrices, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public void onClose() {
+        MinecraftClient.getInstance().openScreen(new F3VerificationScreen(this.parent));
+    }
+}

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ResourcePackVerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ResourcePackVerificationScreen.java
@@ -1,0 +1,35 @@
+package exersolver.mcsrfairplay.verification_screen;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.pack.ResourcePackScreen;
+import net.minecraft.client.util.math.MatrixStack;
+
+import java.util.Objects;
+
+public class ResourcePackVerificationScreen extends VerificationScreen {
+    private final ResourcePackScreen resourcePackScreen;
+
+    public ResourcePackVerificationScreen(Screen parent) {
+        super(parent);
+        this.resourcePackScreen = new ResourcePackScreen(null, MinecraftClient.getInstance().getResourcePackManager(), manager -> {}, MinecraftClient.getInstance().getResourcePackDir());
+    }
+
+    @Override
+    protected void init() {
+        this.resourcePackScreen.init(this.client, this.width, this.height);
+        super.init();
+    }
+
+    @Override
+    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+        this.renderBackgroundTexture(0);
+        this.resourcePackScreen.render(matrices, 0, 0, delta);
+        super.render(matrices, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public void onClose() {
+        MinecraftClient.getInstance().openScreen(new DataPackVerificationScreen(this.parent, Objects.requireNonNull(MinecraftClient.getInstance().getServer())));
+    }
+}

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationListWidget.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationListWidget.java
@@ -15,12 +15,17 @@ import java.util.Map;
 import java.util.Optional;
 
 public class VerificationListWidget extends ElementListWidget<VerificationListWidget.Entry> {
+    private double lastScrollAmount = 0.0;
 
     public VerificationListWidget(MinecraftClient minecraftClient, int width, int height, int top, int bottom, Map<Text, List<List<StringRenderable>>> hashes, int totalHeight) {
         super(minecraftClient, width, height, top, bottom, totalHeight);
         // we cheat the list by only giving it a single entry,
         // so we can implement our own spacing instead of a fixed itemHeight
         this.addEntry(new Entry(hashes));
+    }
+
+    public void updateLastScrollAmount() {
+        this.lastScrollAmount = Math.max(this.lastScrollAmount, this.getScrollAmount());
     }
 
     public boolean isScrolledToBottom() {
@@ -47,6 +52,11 @@ public class VerificationListWidget extends ElementListWidget<VerificationListWi
         // don't consider itemHeight for this calculation
         this.setScrollAmount(this.getScrollAmount() - amount * 15);
         return true;
+    }
+
+    @Override
+    public void setScrollAmount(double amount) {
+        super.setScrollAmount(Math.min(amount, this.lastScrollAmount + 50.0));
     }
 
     @Override
@@ -99,6 +109,7 @@ public class VerificationListWidget extends ElementListWidget<VerificationListWi
         @Override
         public void render(MatrixStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
             TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
+            y += 3;
             for (Map.Entry<Text, List<List<StringRenderable>>> entry : this.hashes.entrySet()) {
                 textRenderer.draw(matrices, entry.getKey(), 10, y, 0xFFFFFF);
                 y += 14;

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
@@ -54,7 +54,7 @@ public class VerificationScreen extends Screen {
 
         this.list = this.addChild(new VerificationListWidget(
                 this.client, this.width, this.height, 32, this.height - 32, hashes,
-                hashes.values().stream().mapToInt(lists -> 14 + lists.stream().mapToInt(list -> list.size() * 10 + 2).sum() + 3).sum()
+                3 + hashes.values().stream().mapToInt(lists -> 14 + lists.stream().mapToInt(list -> list.size() * 10 + 2).sum() + 3).sum()
         ));
 
         this.done = this.addButton(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, new TranslatableText("mcsrfairplay.gui.verification.please_scroll"), button -> this.onClose()));
@@ -68,6 +68,7 @@ public class VerificationScreen extends Screen {
             this.done.active = true;
             this.hasScrolledToBottom = true;
         }
+        this.list.updateLastScrollAmount();
     }
 
     @Override

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
@@ -1,0 +1,55 @@
+package exersolver.mcsrfairplay.verification_screen;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ScreenTexts;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.TranslatableText;
+
+public class VerificationScreen extends Screen {
+    private final Screen parent;
+
+    private ModListWidget list;
+    private ButtonWidget done;
+    private boolean hasScrolledToBottom;
+
+    public VerificationScreen(Screen parent) {
+        super(new TranslatableText("mcsrfairplay.gui.verification.title"));
+        this.parent = parent;
+    }
+
+    @Override
+    protected void init() {
+        this.list = this.addChild(new ModListWidget(this.client, this.width, this.height, 32, this.height - 32, 15));
+        this.done = this.addButton(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, new TranslatableText("mcsrfairplay.gui.verification.please_scroll"), button -> this.onClose()));
+        this.done.active = false;
+    }
+
+    @Override
+    public void tick() {
+        if (!this.hasScrolledToBottom && this.list.isScrolledToBottom()) {
+            this.done.setMessage(ScreenTexts.DONE);
+            this.done.active = true;
+            this.hasScrolledToBottom = true;
+        }
+    }
+
+    @Override
+    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+        this.renderBackground(matrices);
+        this.list.render(matrices, mouseX, mouseY, delta);
+        this.drawCenteredText(matrices, this.textRenderer, this.title, this.width / 2, 15, 0xFFFFFF);
+        super.render(matrices, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public boolean shouldCloseOnEsc() {
+        return this.hasScrolledToBottom;
+    }
+
+    @Override
+    public void onClose() {
+        MinecraftClient.getInstance().openScreen(this.parent);
+    }
+}

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
@@ -22,7 +22,7 @@ public abstract class VerificationScreen extends Screen {
     protected void init() {
         this.next = this.addButton(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, NEXT, button -> this.onClose()));
         this.next.active = false;
-        this.activateNext = System.currentTimeMillis() + 250;
+        this.activateNext = System.nanoTime() + 250_000_000L;
     }
 
     @Override
@@ -33,7 +33,7 @@ public abstract class VerificationScreen extends Screen {
     }
 
     protected boolean shouldActivateNext() {
-        return System.currentTimeMillis() > this.activateNext;
+        return System.nanoTime() > this.activateNext;
     }
 
     @Override

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
@@ -1,16 +1,25 @@
 package exersolver.mcsrfairplay.verification_screen;
 
+import exersolver.mcsrfairplay.ModHashing;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ScreenTexts;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.StringRenderable;
+import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Formatting;
+
+import java.util.*;
 
 public class VerificationScreen extends Screen {
     private final Screen parent;
 
-    private ModListWidget list;
+    private VerificationListWidget list;
     private ButtonWidget done;
     private boolean hasScrolledToBottom;
 
@@ -21,7 +30,33 @@ public class VerificationScreen extends Screen {
 
     @Override
     protected void init() {
-        this.list = this.addChild(new ModListWidget(this.client, this.width, this.height, 32, this.height - 32, 15));
+        Map<Text, List<List<StringRenderable>>> hashes = new LinkedHashMap<>();
+
+        List<ModContainer> mods = new ArrayList<>(FabricLoader.getInstance().getAllMods());
+        mods.sort(Comparator.comparing(mod -> mod.getMetadata().getName()));
+        for (ModContainer mod : mods) {
+            String id = mod.getMetadata().getId();
+            String modHash = ModHashing.MOD_HASHES.get(id);
+            String fileHash = ModHashing.FILE_HASHES.get(id);
+
+            Text text = new LiteralText(mod.getMetadata().getName()).append(
+                    new LiteralText(" (" + id + "-" + mod.getMetadata().getVersion().getFriendlyString() + ")").formatted(Formatting.GRAY)
+            );
+
+            List<List<StringRenderable>> lists = new ArrayList<>();
+            lists.add(this.textRenderer.wrapLines(StringRenderable.plain(modHash), this.width - 30));
+            if (fileHash != null) {
+                lists.add(this.textRenderer.wrapLines(StringRenderable.plain(fileHash), this.width - 30));
+            }
+
+            hashes.put(text, lists);
+        }
+
+        this.list = this.addChild(new VerificationListWidget(
+                this.client, this.width, this.height, 32, this.height - 32, hashes,
+                hashes.values().stream().mapToInt(lists -> 14 + lists.stream().mapToInt(list -> list.size() * 10 + 2).sum() + 3).sum()
+        ));
+
         this.done = this.addButton(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, new TranslatableText("mcsrfairplay.gui.verification.please_scroll"), button -> this.onClose()));
         this.done.active = false;
     }

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
@@ -2,6 +2,7 @@ package exersolver.mcsrfairplay.verification_screen;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 
@@ -9,6 +10,8 @@ public abstract class VerificationScreen extends Screen {
     public static final Text NEXT = new TranslatableText("mcsrfairplay.gui.verification.next_page");
 
     protected final Screen parent;
+    protected ButtonWidget next;
+    private long activateNext;
 
     protected VerificationScreen(Screen parent) {
         super(new TranslatableText("mcsrfairplay.gui.verification.title"));
@@ -16,8 +19,26 @@ public abstract class VerificationScreen extends Screen {
     }
 
     @Override
+    protected void init() {
+        this.next = this.addButton(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, NEXT, button -> this.onClose()));
+        this.next.active = false;
+        this.activateNext = System.currentTimeMillis() + 250;
+    }
+
+    @Override
+    public void tick() {
+        if (!this.next.active && this.shouldActivateNext()) {
+            this.next.active = true;
+        }
+    }
+
+    protected boolean shouldActivateNext() {
+        return System.currentTimeMillis() > this.activateNext;
+    }
+
+    @Override
     public boolean shouldCloseOnEsc() {
-        return false;
+        return this.next.active;
     }
 
     public static void start() {

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/VerificationScreen.java
@@ -1,91 +1,26 @@
 package exersolver.mcsrfairplay.verification_screen;
 
-import exersolver.mcsrfairplay.ModHashing;
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ScreenTexts;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.text.LiteralText;
-import net.minecraft.text.StringRenderable;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
-import net.minecraft.util.Formatting;
 
-import java.util.*;
+public abstract class VerificationScreen extends Screen {
+    public static final Text NEXT = new TranslatableText("mcsrfairplay.gui.verification.next_page");
 
-public class VerificationScreen extends Screen {
-    private final Screen parent;
+    protected final Screen parent;
 
-    private VerificationListWidget list;
-    private ButtonWidget done;
-    private boolean hasScrolledToBottom;
-
-    public VerificationScreen(Screen parent) {
+    protected VerificationScreen(Screen parent) {
         super(new TranslatableText("mcsrfairplay.gui.verification.title"));
         this.parent = parent;
     }
 
     @Override
-    protected void init() {
-        Map<Text, List<List<StringRenderable>>> hashes = new LinkedHashMap<>();
-
-        List<ModContainer> mods = new ArrayList<>(FabricLoader.getInstance().getAllMods());
-        mods.sort(Comparator.comparing(mod -> mod.getMetadata().getName()));
-        for (ModContainer mod : mods) {
-            String id = mod.getMetadata().getId();
-            String modHash = ModHashing.MOD_HASHES.get(id);
-            String fileHash = ModHashing.FILE_HASHES.get(id);
-
-            Text text = new LiteralText(mod.getMetadata().getName()).append(
-                    new LiteralText(" (" + id + "-" + mod.getMetadata().getVersion().getFriendlyString() + ")").formatted(Formatting.GRAY)
-            );
-
-            List<List<StringRenderable>> lists = new ArrayList<>();
-            lists.add(this.textRenderer.wrapLines(StringRenderable.plain(modHash), this.width - 30));
-            if (fileHash != null) {
-                lists.add(this.textRenderer.wrapLines(StringRenderable.plain(fileHash), this.width - 30));
-            }
-
-            hashes.put(text, lists);
-        }
-
-        this.list = this.addChild(new VerificationListWidget(
-                this.client, this.width, this.height, 32, this.height - 32, hashes,
-                3 + hashes.values().stream().mapToInt(lists -> 14 + lists.stream().mapToInt(list -> list.size() * 10 + 2).sum() + 3).sum()
-        ));
-
-        this.done = this.addButton(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, new TranslatableText("mcsrfairplay.gui.verification.please_scroll"), button -> this.onClose()));
-        this.done.active = false;
-    }
-
-    @Override
-    public void tick() {
-        if (!this.hasScrolledToBottom && this.list.isScrolledToBottom()) {
-            this.done.setMessage(ScreenTexts.DONE);
-            this.done.active = true;
-            this.hasScrolledToBottom = true;
-        }
-        this.list.updateLastScrollAmount();
-    }
-
-    @Override
-    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
-        this.renderBackground(matrices);
-        this.list.render(matrices, mouseX, mouseY, delta);
-        this.drawCenteredText(matrices, this.textRenderer, this.title, this.width / 2, 15, 0xFFFFFF);
-        super.render(matrices, mouseX, mouseY, delta);
-    }
-
-    @Override
     public boolean shouldCloseOnEsc() {
-        return this.hasScrolledToBottom;
+        return false;
     }
 
-    @Override
-    public void onClose() {
-        MinecraftClient.getInstance().openScreen(this.parent);
+    public static void start() {
+        MinecraftClient.getInstance().openScreen(new ModVerificationScreen(MinecraftClient.getInstance().currentScreen));
     }
 }

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesExplanationListWidget.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesExplanationListWidget.java
@@ -1,0 +1,110 @@
+package exersolver.mcsrfairplay.verification_screen;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.widget.ElementListWidget;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.StringRenderable;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class ZipFilesExplanationListWidget extends ElementListWidget<ZipFilesExplanationListWidget.Entry> {
+
+    public ZipFilesExplanationListWidget(MinecraftClient minecraftClient, int width, int height, int top, int bottom, List<List<StringRenderable>> lines, int totalHeight) {
+        super(minecraftClient, width, height, top, bottom, totalHeight);
+        // we cheat the list by only giving it a single entry,
+        // so we can implement our own spacing instead of a fixed itemHeight
+        this.addEntry(new Entry(lines));
+    }
+
+    @Override
+    public int getRowWidth() {
+        return this.width - 50;
+    }
+
+    @Override
+    protected int getRowLeft() {
+        return 25;
+    }
+
+    @Override
+    protected int getScrollbarPositionX() {
+        if (this.height < this.itemHeight) {
+            // don't render scrollbar if there is nothing to scroll
+            return this.width;
+        }
+        return this.width - 6;
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double amount) {
+        // don't consider itemHeight for this calculation
+        this.setScrollAmount(this.getScrollAmount() - amount * 15);
+        return true;
+    }
+
+    @Override
+    protected int getMaxPosition() {
+        return super.getMaxPosition();
+    }
+
+    @Override
+    public Optional<Element> hoveredElement(double mouseX, double mouseY) {
+        return super.hoveredElement(mouseX, mouseY);
+    }
+
+    @Override
+    public void mouseMoved(double mouseX, double mouseY) {
+        super.mouseMoved(mouseX, mouseY);
+    }
+
+    @Override
+    public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
+        return super.keyReleased(keyCode, scanCode, modifiers);
+    }
+
+    @Override
+    public boolean charTyped(char chr, int keyCode) {
+        return super.charTyped(chr, keyCode);
+    }
+
+    @Override
+    public void setInitialFocus(@Nullable Element element) {
+        super.setInitialFocus(element);
+    }
+
+    @Override
+    public void focusOn(@Nullable Element element) {
+        super.focusOn(element);
+    }
+
+    public static class Entry extends ElementListWidget.Entry<Entry> {
+        private final List<List<StringRenderable>> lines;
+
+        public Entry(List<List<StringRenderable>> lines) {
+            this.lines = lines;
+        }
+
+        @Override
+        public List<? extends Element> children() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void render(MatrixStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+            TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
+            y += 3;
+            for (List<StringRenderable> line : this.lines) {
+                for (StringRenderable string : line) {
+                    textRenderer.draw(matrices, string, 10, y, 0xFFFFFF);
+                    y += 10;
+                }
+                y += 3;
+            }
+        }
+    }
+}

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesExplanationListWidget.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesExplanationListWidget.java
@@ -6,11 +6,9 @@ import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.widget.ElementListWidget;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.StringRenderable;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 public class ZipFilesExplanationListWidget extends ElementListWidget<ZipFilesExplanationListWidget.Entry> {
 
@@ -45,41 +43,6 @@ public class ZipFilesExplanationListWidget extends ElementListWidget<ZipFilesExp
         // don't consider itemHeight for this calculation
         this.setScrollAmount(this.getScrollAmount() - amount * 15);
         return true;
-    }
-
-    @Override
-    protected int getMaxPosition() {
-        return super.getMaxPosition();
-    }
-
-    @Override
-    public Optional<Element> hoveredElement(double mouseX, double mouseY) {
-        return super.hoveredElement(mouseX, mouseY);
-    }
-
-    @Override
-    public void mouseMoved(double mouseX, double mouseY) {
-        super.mouseMoved(mouseX, mouseY);
-    }
-
-    @Override
-    public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
-        return super.keyReleased(keyCode, scanCode, modifiers);
-    }
-
-    @Override
-    public boolean charTyped(char chr, int keyCode) {
-        return super.charTyped(chr, keyCode);
-    }
-
-    @Override
-    public void setInitialFocus(@Nullable Element element) {
-        super.setInitialFocus(element);
-    }
-
-    @Override
-    public void focusOn(@Nullable Element element) {
-        super.focusOn(element);
     }
 
     public static class Entry extends ElementListWidget.Entry<Entry> {

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesScreen.java
@@ -201,7 +201,7 @@ public class ZipFilesScreen extends Screen {
                 return Optional.of(worlds);
             }
 
-            for (int i = 1; i <= 100; i++) {
+            for (int i = 1; true; i++) {
                 Path nextWorld = this.findWorldAtum(saves, prefix, count + i);
                 if (nextWorld == null) {
                     break;

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesScreen.java
@@ -347,7 +347,7 @@ public class ZipFilesScreen extends Screen {
 
     private enum Phase {
         NONE,
-        DISCONNECT("menu.savingLevel"),
+        DISCONNECT("menu.savingLevel", true),
         ZIP_FILES("mcsrfairplay.gui.zip_files.zipping_files", true),
         FINISHED("mcsrfairplay.gui.zip_files.finished_zipping"),
         FAILURE("mcsrfairplay.gui.zip_files.failed_zipping");

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesScreen.java
@@ -6,7 +6,6 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ConfirmScreen;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ScreenTexts;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.resource.ClientResourcePackProfile;
@@ -61,12 +60,12 @@ public class ZipFilesScreen extends Screen {
                 this.zipFiles();
             }));
         } else {
-            this.addButton(new ButtonWidget(this.width / 2 - 160, this.height - 27, 150, 20, new TranslatableText("mcsrfairplay.gui.zip_files.open_directory"), button -> this.openDirectory()));
-            this.addButton(new ButtonWidget(this.width / 2 + 10, this.height - 27, 150, 20, ScreenTexts.DONE, button -> {
+            this.addButton(new ButtonWidget(this.width / 2 - 160, this.height - 27, 150, 20, new TranslatableText("gui.toTitle"), button -> {
                 if (!this.phase.blocking) {
                     this.onClose();
                 }
             }));
+            this.addButton(new ButtonWidget(this.width / 2 + 10, this.height - 27, 150, 20, new TranslatableText("mcsrfairplay.gui.zip_files.open_directory"), button -> this.openDirectory()));
         }
 
         String[] explanation = new String[]{

--- a/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesScreen.java
+++ b/src/main/java/exersolver/mcsrfairplay/verification_screen/ZipFilesScreen.java
@@ -1,0 +1,321 @@
+package exersolver.mcsrfairplay.verification_screen;
+
+import exersolver.mcsrfairplay.MCSRFairplay;
+import exersolver.mcsrfairplay.mixin.accessor.MinecraftClientAccessor;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConfirmScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ScreenTexts;
+import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.resource.ClientResourcePackProfile;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.StringRenderable;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.FileNameUtil;
+import net.minecraft.util.Pair;
+import net.minecraft.util.Util;
+import net.minecraft.util.WorldSavePath;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class ZipFilesScreen extends Screen {
+    private static final String ATUM_REGEX = "(Random|Set) Speedrun #\\d+( \\(\\d+\\))?$";
+
+    private final Screen parent;
+
+    private Phase phase = Phase.NONE;
+    private ZipFilesExplanationListWidget explanation;
+
+    public ZipFilesScreen(Screen parent) {
+        super(new TranslatableText("mcsrfairplay.gui.zip_files.title"));
+        this.parent = parent;
+    }
+
+    @Override
+    protected void init() {
+        if (this.phase == Phase.NONE) {
+            this.addButton(new ButtonWidget(this.width / 2 - 160, this.height - 27, 150, 20, new TranslatableText("mcsrfairplay.gui.zip_files.skip_zip"), button -> this.onClose()));
+            this.addButton(new ButtonWidget(this.width / 2 + 10, this.height - 27, 150, 20, new TranslatableText("mcsrfairplay.gui.zip_files.zip_files"), button -> {
+                button.visible = false;
+                this.zip();
+            }));
+        } else {
+            this.addButton(new ButtonWidget(this.width / 2 - 160, this.height - 27, 150, 20, new TranslatableText("mcsrfairplay.gui.zip_files.open_directory"), button -> this.openDirectory()));
+            this.addButton(new ButtonWidget(this.width / 2 + 10, this.height - 27, 150, 20, ScreenTexts.DONE, button -> this.onClose()));
+        }
+
+        String[] explanation = new String[]{
+                "For certain categories or when achieving certain times, additional proof may be required to verify your run.",
+                "This can include (but may not be limited to) world files and the latest.log of the current minecraft session.",
+                "",
+                "When using resource packs other than the vanilla resource packs, you are also required to submit their files.",
+                "",
+                "By pressing 'Zip Files', these files will be zipped and put into the .minecraft/mcsrfairplay/ directory.",
+                "If possible, the created file will automatically be opened in your file explorer, otherwise you may have to check that directory manually",
+                "",
+                "Before uploading this file when submitting your run to the leaderboard, please check the submission rules to make sure all required files are included!"
+        };
+
+        List<List<StringRenderable>> lines = Arrays.stream(explanation)
+                .map(StringRenderable::plain)
+                .map(line -> MinecraftClient.getInstance().textRenderer.wrapLines(line, this.width - 50))
+                .collect(Collectors.toList());
+
+        this.explanation = this.addChild(new ZipFilesExplanationListWidget(
+                this.client, this.width, this.height, 32, this.height - 32, lines,
+                3 + lines.stream().mapToInt(line -> line.size() * 10 + 3).sum()
+        ));
+
+        super.init();
+    }
+
+    private void zip() {
+        if (this.phase != Phase.NONE) {
+            return;
+        }
+        MinecraftClient client = MinecraftClient.getInstance();
+        MinecraftServer server = client.getServer();
+
+        String fileName = client.getSession().getUsername() + "-" + (server != null ? server.getSavePath(WorldSavePath.ROOT).getParent().getFileName() : "multiplayer") + "-" + new SimpleDateFormat("yyyy-MM-dd-hh-mm").format(new Date());
+
+        this.phase = Phase.DISCONNECT;
+        this.disconnect(client);
+
+        this.phase = Phase.ZIP_FILES;
+        this.render(client);
+        try {
+            this.zipFiles(client, server, fileName);
+            this.phase = Phase.FINISHED;
+        } catch (Exception e) {
+            MCSRFairplay.LOGGER.error("Failed to zip verification files", e);
+            this.phase = Phase.FAILURE;
+        }
+    }
+
+    private void disconnect(MinecraftClient client) {
+        ClientWorld world = client.world;
+        if (world != null) {
+            world.disconnect();
+            client.disconnect(this);
+        }
+    }
+
+    private void render(MinecraftClient client) {
+        ((MinecraftClientAccessor) client).mcsrfairplay$render(false);
+    }
+
+    private void zipFiles(MinecraftClient client, @Nullable MinecraftServer server, String fileName) throws IOException {
+        Files.createDirectories(MCSRFairplay.DIRECTORY);
+        Path zip = MCSRFairplay.DIRECTORY.resolve(FileNameUtil.getNextUniqueName(MCSRFairplay.DIRECTORY, fileName, ".zip"));
+        Files.createFile(zip);
+
+        try (ZipOutputStream output = new ZipOutputStream(Files.newOutputStream(zip))) {
+            if (server != null) {
+                this.zipWorlds(output, client, server);
+            }
+            this.zipResourcePacks(output, client);
+            this.zipLog(output);
+        }
+    }
+
+    private void zipWorlds(ZipOutputStream zip, MinecraftClient client, MinecraftServer server) throws IOException {
+        Path world = server.getSavePath(WorldSavePath.ROOT).getParent();
+        this.zipPath(zip, "world_file/", world);
+
+        if (!this.zipWorldsAtum(zip, client, server)) {
+            System.out.println("zipWorldsVanilla");
+            this.zipWorldsVanilla(zip, client, server);
+        }
+    }
+
+    private boolean zipWorldsAtum(ZipOutputStream zip, MinecraftClient client, MinecraftServer server) throws IOException {
+        if (!FabricLoader.getInstance().isModLoaded("atum")) {
+            return false;
+        }
+        String world = server.getSavePath(WorldSavePath.ROOT).getParent().getFileName().toString();
+        if (!world.matches(ATUM_REGEX)) {
+            return false;
+        }
+
+        Path saves = client.getLevelStorage().getSavesDirectory();
+        int countStart = world.indexOf('#') + 1;
+        int countEnd = world.indexOf(' ', countStart);
+        if (countEnd == -1) {
+            countEnd = world.length();
+        }
+        try {
+            String prefix = world.substring(0, countStart);
+            int count = Integer.parseInt(world.substring(countStart, countEnd));
+
+            // zip 5 previous resets
+            for (int i = 1; i <= 5; i++) {
+                Path previousWorld = this.findWorldAtum(saves, prefix, count - i);
+                if (previousWorld == null) {
+                    MCSRFairplay.LOGGER.warn("Only found {} old atum worlds!", i - 1);
+                    break;
+                }
+                this.zipPath(zip, "world_files/", previousWorld);
+            }
+
+            // zip up to 100 resets after if SeedQueue is loaded
+            if (!FabricLoader.getInstance().isModLoaded("seedqueue")) {
+                return true;
+            }
+
+            for (int i = 1; i <= 100; i++) {
+                Path nextWorld = this.findWorldAtum(saves, prefix, count + i);
+                if (nextWorld == null) {
+                    break;
+                }
+                this.zipPath(zip, "world_files/", nextWorld);
+            }
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        return true;
+    }
+
+    private Path findWorldAtum(Path saves, String prefix, int counter) {
+        String name = prefix + counter;
+        Path world = saves.resolve(name);
+        if (!Files.exists(world)) {
+            return null;
+        }
+
+        // If a Random Speedrun #1234 directory already exists,
+        // Atum will instead create Random Speedrun #1234 (1)
+        // and we have to find the latest one
+        int uniqueNumber = 1;
+        while (Files.exists(saves.resolve(name + " (" + uniqueNumber + ")"))) {
+            world = saves.resolve(name + " (" + uniqueNumber + ")");
+        }
+
+        return world;
+    }
+
+    private void zipWorldsVanilla(ZipOutputStream zip, MinecraftClient client, MinecraftServer server) throws IOException {
+        Path world = server.getSavePath(WorldSavePath.ROOT).getParent();
+
+        SortedSet<Pair<Path, Long>> previousWorlds = new TreeSet<>(Comparator.comparing(Pair::getRight));
+        for (File file : Objects.requireNonNull(client.getLevelStorage().getSavesDirectory().toFile().listFiles())) {
+            Path path = file.toPath();
+            if (path.equals(world)) {
+                continue;
+            }
+            Path levelDat = path.resolve("level.dat");
+            if (!Files.exists(levelDat)) {
+                continue;
+            }
+
+            long lastModified = Files.getLastModifiedTime(levelDat).toMillis();
+            if (previousWorlds.size() < 5) {
+                previousWorlds.add(new Pair<>(path, lastModified));
+                continue;
+            }
+
+            Pair<Path, Long> oldestWorld = previousWorlds.first();
+            if (lastModified > oldestWorld.getRight()) {
+                previousWorlds.remove(oldestWorld);
+                previousWorlds.add(new Pair<>(path, lastModified));
+            }
+        }
+
+        for (Pair<Path, Long> previousWorld : previousWorlds) {
+            this.zipPath(zip, "world_files/", previousWorld.getLeft());
+        }
+    }
+
+    private void zipResourcePacks(ZipOutputStream zip, MinecraftClient client) throws IOException {
+        for (ClientResourcePackProfile pack : client.getResourcePackManager().getEnabledProfiles()) {
+            String name = pack.getName();
+            if (name.startsWith("file/")) {
+                this.zipPath(zip, "resource_packs/", client.getResourcePackDir().toPath().resolve(name.substring("file/".length())));
+            }
+        }
+    }
+
+    private void zipLog(ZipOutputStream zip) throws IOException {
+        this.zipPath(zip, "logs/", Paths.get("logs/latest.log"));
+    }
+
+    private void zipPath(ZipOutputStream zip, String prefix, Path path) throws IOException {
+        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                zip.putNextEntry(new ZipEntry(prefix + path.getParent().relativize(file)));
+                Files.copy(file, zip);
+                zip.closeEntry();
+                return FileVisitResult.CONTINUE;
+            }
+
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                zip.putNextEntry(new ZipEntry(prefix + path.getParent().relativize(dir) + "/"));
+                zip.closeEntry();
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private void openDirectory() {
+        Util.getOperatingSystem().open(MCSRFairplay.DIRECTORY.toFile());
+    }
+
+    @Override
+    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+        this.renderBackgroundTexture(0);
+        if (this.phase == Phase.NONE) {
+            this.explanation.render(matrices, mouseX, mouseY, delta);
+        } else {
+            this.drawCenteredText(matrices, this.textRenderer, this.phase.text, this.width / 2, 70, 0xFFFFFF);
+        }
+        this.drawCenteredText(matrices, this.textRenderer, this.title, this.width / 2, 15, 0xFFFFFF);
+        super.render(matrices, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public void onClose() {
+        if (this.phase != Phase.NONE) {
+            MinecraftClient.getInstance().openScreen(new TitleScreen());
+            return;
+        }
+        MinecraftClient.getInstance().openScreen(new ConfirmScreen(confirm -> {
+            if (confirm) {
+                MinecraftClient.getInstance().openScreen(this.parent);
+            } else {
+                MinecraftClient.getInstance().openScreen(this);
+            }
+        }, new TranslatableText("mcsrfairplay.gui.zip_files.confirm_skip"), LiteralText.EMPTY));
+    }
+
+    private enum Phase {
+        NONE,
+        DISCONNECT("menu.savingLevel"),
+        ZIP_FILES("mcsrfairplay.gui.zip_files.zipping_files"),
+        FINISHED("mcsrfairplay.gui.zip_files.finished_zipping"),
+        FAILURE("mcsrfairplay.gui.zip_files.failed_zipping");
+
+        private final Text text;
+
+        Phase() {
+            this.text = null;
+        }
+
+        Phase(String key) {
+            this.text = new TranslatableText(key);
+        }
+    }
+}

--- a/src/main/resources/assets/mcsrfairplay/lang/en_us.json
+++ b/src/main/resources/assets/mcsrfairplay/lang/en_us.json
@@ -10,6 +10,7 @@
   "mcsrfairplay.gui.zip_files.skip_zip": "Skip",
   "mcsrfairplay.gui.zip_files.open_directory": "Open Directory",
   "mcsrfairplay.gui.zip_files.zip_files": "Zip Files",
+  "mcsrfairplay.gui.zip_files.stopping_atum": "Stopping Atum...",
   "mcsrfairplay.gui.zip_files.zipping_files": "Zipping files...",
   "mcsrfairplay.gui.zip_files.finished_zipping": "Finished zipping files, press 'Open Directory' to get your file.",
   "mcsrfairplay.gui.zip_files.failed_zipping": "Something went wrong when zipping your files!",

--- a/src/main/resources/assets/mcsrfairplay/lang/en_us.json
+++ b/src/main/resources/assets/mcsrfairplay/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "mcsrfairplay.gui.verification.title": "Verification Screen",
+  "mcsrfairplay.gui.verification.message": "Click %s for verification",
+  "mcsrfairplay.gui.verification.here": "here",
+  "mcsrfairplay.gui.verification.tooltip": "Click to open Verification Screen",
+  "mcsrfairplay.gui.verification.please_scroll": "Please scroll down!"
+}

--- a/src/main/resources/assets/mcsrfairplay/lang/en_us.json
+++ b/src/main/resources/assets/mcsrfairplay/lang/en_us.json
@@ -4,5 +4,14 @@
   "mcsrfairplay.gui.verification.here": "HERE",
   "mcsrfairplay.gui.verification.tooltip": "Click to open Verification Screen",
   "mcsrfairplay.gui.verification.please_scroll": "Please scroll down!",
-  "mcsrfairplay.gui.verification.next_page": "Next Page"
+  "mcsrfairplay.gui.verification.next_page": "Next Page",
+
+  "mcsrfairplay.gui.zip_files.title": "Zip Additional Proof",
+  "mcsrfairplay.gui.zip_files.skip_zip": "Skip",
+  "mcsrfairplay.gui.zip_files.open_directory": "Open Directory",
+  "mcsrfairplay.gui.zip_files.zip_files": "Zip Files",
+  "mcsrfairplay.gui.zip_files.zipping_files": "Zipping files...",
+  "mcsrfairplay.gui.zip_files.finished_zipping": "Finished zipping files, press 'Open Directory' to get your file.",
+  "mcsrfairplay.gui.zip_files.failed_zipping": "Something went wrong when zipping your files!",
+  "mcsrfairplay.gui.zip_files.confirm_skip": "Are you sure you don't want to zip your files for verification?"
 }

--- a/src/main/resources/assets/mcsrfairplay/lang/en_us.json
+++ b/src/main/resources/assets/mcsrfairplay/lang/en_us.json
@@ -3,5 +3,6 @@
   "mcsrfairplay.gui.verification.message": "Click %s for verification",
   "mcsrfairplay.gui.verification.here": "HERE",
   "mcsrfairplay.gui.verification.tooltip": "Click to open Verification Screen",
-  "mcsrfairplay.gui.verification.please_scroll": "Please scroll down!"
+  "mcsrfairplay.gui.verification.please_scroll": "Please scroll down!",
+  "mcsrfairplay.gui.verification.next_page": "Next Page"
 }

--- a/src/main/resources/assets/mcsrfairplay/lang/en_us.json
+++ b/src/main/resources/assets/mcsrfairplay/lang/en_us.json
@@ -1,7 +1,7 @@
 {
   "mcsrfairplay.gui.verification.title": "Verification Screen",
   "mcsrfairplay.gui.verification.message": "Click %s for verification",
-  "mcsrfairplay.gui.verification.here": "here",
+  "mcsrfairplay.gui.verification.here": "HERE",
   "mcsrfairplay.gui.verification.tooltip": "Click to open Verification Screen",
   "mcsrfairplay.gui.verification.please_scroll": "Please scroll down!"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,6 +16,9 @@
 	"icon": "assets/mcsrfairplay/icon.png",
 	"environment": "client",
 	"entrypoints": {
+		"preLaunch": [
+			"exersolver.mcsrfairplay.MCSRFairplay"
+		],
 		"client": [
 			"exersolver.mcsrfairplay.MCSRFairplay"
 		]
@@ -26,6 +29,7 @@
 	"depends": {
 		"fabricloader": ">=0.16.0",
 		"minecraft": ">=1.16 <=1.16.1",
-		"java": ">=8"
+		"java": ">=8",
+		"speedrunapi": "*"
 	}
 }

--- a/src/main/resources/mcsrfairplay.mixins.json
+++ b/src/main/resources/mcsrfairplay.mixins.json
@@ -10,6 +10,7 @@
     "MinecraftClientMixin",
     "MouseMixin",
     "SaveLevelScreenMixin",
+    "ScreenMixin",
     "WindowMixin"
   ]
 }

--- a/src/main/resources/mcsrfairplay.mixins.json
+++ b/src/main/resources/mcsrfairplay.mixins.json
@@ -6,6 +6,7 @@
     "defaultRequire": 1
   },
   "client": [
+    "accessor.MinecraftClientAccessor",
     "ClientPlayerEntityMixin",
     "MinecraftClientMixin",
     "MouseMixin",


### PR DESCRIPTION
- hashes loaded mod contents (including minecraft, fabricloader and java) using the root paths given by `ModContainer#getRootPaths`
- hashes mod files in their original location as given by `ModOrigin#getPaths` for easy comparison with legal-mods, see https://github.com/Minecraft-Java-Edition-Speedrunning/legal-mods/pull/111
- adds a verification screen that can be opened through a message sent on /seed, showing:
  - mod hashes
  - f3 screen
  - resource/data packs
- adds a screen to zip additional proof after the verification screen, including:
  - world file
  - 5 previous world files and any after if SeedQueue is loaded
  - logs within two days of the current time
  - resource packs

notes:
- servers could send messages with the metadata used for the verification screen open prompt, this means they could technically prompt the verification screen to be opened (if the user clicks on it), I doubt this is a concern but should atleast be mentioned
- currently 'Open Directory' only opens the `.minecraft/mcsrfairplay/` directory, is there a good, preferrably platform-independent, alternative to `Desktop#browseFileDirectory` to automatically have the relevant file selected?
- since everything else is translatable, the explanation text should probably be translatable aswell